### PR TITLE
CI/CD 파이프라인 docker-compose 기반으로 전환 및 EC2 자동 배포 설정

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -60,7 +60,17 @@ jobs:
         source: "docker-compose.yml"
         target: "~/realtimetrip"
 
-    # EC2에 접속해 .env, application.yml 생성 + docker-compose 실행
+    # application.yml 생성 (마운트용)
+    - name: Create application.yml on EC2
+      uses: appleboy/ssh-action@v0.1.6
+      with:
+        host: ${{ secrets.EC2_HOST }}
+        username: ${{ secrets.EC2_USERNAME }}
+        key: ${{ secrets.EC2_KEY }}
+        script: |
+          echo "${{ secrets.APPLICATION }}" > ~/realtimetrip/application.yml
+
+    # EC2에서 Docker Compose로 애플리케이션 실행
     - name: Application Run
       uses: appleboy/ssh-action@v0.1.6
       with:
@@ -68,18 +78,6 @@ jobs:
         username: ${{ secrets.EC2_USERNAME }}
         key: ${{ secrets.EC2_KEY }}
         script: |
-          # .env 파일 생성
-          echo "PORT=${{ secrets.PORT }}" > ~/realtimetrip/.env
-          echo "DB_URL=${{ secrets.DB_URL }}" >> ~/realtimetrip/.env
-          echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> ~/realtimetrip/.env
-          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> ~/realtimetrip/.env
-          echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> ~/realtimetrip/.env
-          echo "PROJECT_NAME=${{ secrets.PROJECT_NAME }}" >> ~/realtimetrip/.env
-
-          # application.yml 생성
-          echo "${{ secrets.APPLICATION }}" > ~/realtimetrip/src/main/resources/application.yml
-
-          # docker-compose 실행
           cd ~/realtimetrip
           sudo docker compose pull
           sudo docker compose down

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,9 +27,6 @@ jobs:
         java-version: '17'
         distribution: 'corretto'
         
-    - run : touch ./src/main/resources/application.yml
-    - run : echo "${{ secrets.APPLICATION }}" > ./src/main/resources/application.yml
-        
     # Gradle Build를 위한 권한 부여
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
@@ -53,21 +50,7 @@ jobs:
     - name: DockerHub Push
       run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}
 
-    # EC2에 .env 파일 생성 (GitHub Secrets 기반)
-    - name: Create .env file in EC2
-      uses: appleboy/ssh-action@v0.1.6
-      with:
-        host: ${{ secrets.EC2_HOST }}
-        username: ${{ secrets.EC2_USERNAME }}
-        key: ${{ secrets.EC2_KEY }}
-        script: |
-          echo "PORT=${{ secrets.PORT }}" > ~/realtimetrip/.env
-          echo "DB_URL=${{ secrets.DB_URL }}" >> ~/realtimetrip/.env
-          echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> ~/realtimetrip/.env
-          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> ~/realtimetrip/.env
-          echo "REDIS_PORT=${{ secrets.REDIS_PORT }}" >> ~/realtimetrip/.env
-
-    # C2에 docker-compose.yml 파일 복사
+    # EC2에 docker-compose.yml 파일 복사
     - name: Copy docker-compose.yml to EC2
       uses: appleboy/scp-action@v0.1.5
       with:
@@ -77,15 +60,24 @@ jobs:
         source: "docker-compose.yml"
         target: "~/realtimetrip"
 
-      # EC2 인스턴스에 접속하여 docker-compose로 애플리케이션과 Redis를 실행하는 단계
+    # EC2에 접속해 .env, application.yml 생성 + docker-compose 실행
     - name: Application Run
       uses: appleboy/ssh-action@v0.1.6
       with:
         host: ${{ secrets.EC2_HOST }}
         username: ${{ secrets.EC2_USERNAME }}
         key: ${{ secrets.EC2_KEY }}
-
         script: |
+          # .env 파일 생성
+          echo "PORT=${{ secrets.PORT }}" > ~/realtimetrip/.env
+          echo "DB_URL=${{ secrets.DB_URL }}" >> ~/realtimetrip/.env
+          echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> ~/realtimetrip/.env
+          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> ~/realtimetrip/.env
+
+          # application.yml 생성
+          echo "${{ secrets.APPLICATION }}" > ~/realtimetrip/src/main/resources/application.yml
+
+          # docker-compose 실행
           cd ~/realtimetrip
           sudo docker compose pull
           sudo docker compose down

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -73,6 +73,8 @@ jobs:
           echo "DB_URL=${{ secrets.DB_URL }}" >> ~/realtimetrip/.env
           echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> ~/realtimetrip/.env
           echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> ~/realtimetrip/.env
+          echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> ~/realtimetrip/.env
+          echo "PROJECT_NAME=${{ secrets.PROJECT_NAME }}" >> ~/realtimetrip/.env
 
           # application.yml 생성
           echo "${{ secrets.APPLICATION }}" > ~/realtimetrip/src/main/resources/application.yml

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -53,6 +53,20 @@ jobs:
     - name: DockerHub Push
       run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}
 
+    # EC2에 .env 파일 생성 (GitHub Secrets 기반)
+    - name: Create .env file in EC2
+      uses: appleboy/ssh-action@v0.1.6
+      with:
+        host: ${{ secrets.EC2_HOST }}
+        username: ${{ secrets.EC2_USERNAME }}
+        key: ${{ secrets.EC2_KEY }}
+        script: |
+          echo "PORT=${{ secrets.PORT }}" > ~/realtimetrip/.env
+          echo "DB_URL=${{ secrets.DB_URL }}" >> ~/realtimetrip/.env
+          echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> ~/realtimetrip/.env
+          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> ~/realtimetrip/.env
+          echo "REDIS_PORT=${{ secrets.REDIS_PORT }}" >> ~/realtimetrip/.env
+
     # C2에 docker-compose.yml 파일 복사
     - name: Copy docker-compose.yml to EC2
       uses: appleboy/scp-action@v0.1.5

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -53,7 +53,17 @@ jobs:
     - name: DockerHub Push
       run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}
 
-    # EC2 인스턴스에 접속하여 docker-compose로 애플리케이션과 Redis를 실행하는 단계
+    # C2에 docker-compose.yml 파일 복사
+    - name: Copy docker-compose.yml to EC2
+      uses: appleboy/scp-action@v0.1.5
+      with:
+        host: ${{ secrets.EC2_HOST }}
+        username: ${{ secrets.EC2_USERNAME }}
+        key: ${{ secrets.EC2_KEY }}
+        source: "docker-compose.yml"
+        target: "~/realtimetrip"
+
+      # EC2 인스턴스에 접속하여 docker-compose로 애플리케이션과 Redis를 실행하는 단계
     - name: Application Run
       uses: appleboy/ssh-action@v0.1.6
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -70,6 +70,18 @@ jobs:
         script: |
           echo "${{ secrets.APPLICATION }}" > ~/realtimetrip/application.yml
 
+    # EC2에 .env 파일 생성 (.env는 docker-compose에서 참조하는 환경 변수 파일)
+    - name: Create .env file on EC2
+      uses: appleboy/ssh-action@v0.1.6
+      with:
+        host: ${{ secrets.EC2_HOST }}
+        username: ${{ secrets.EC2_USERNAME }}
+        key: ${{ secrets.EC2_KEY }}
+        script: |
+          echo "PORT=${{ secrets.PORT }}" > ~/realtimetrip/.env
+          echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> ~/realtimetrip/.env
+          echo "PROJECT_NAME=${{ secrets.PROJECT_NAME }}" >> ~/realtimetrip/.env
+
     # EC2에서 Docker Compose로 애플리케이션 실행
     - name: Application Run
       uses: appleboy/ssh-action@v0.1.6

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -53,7 +53,7 @@ jobs:
     - name: DockerHub Push
       run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}
 
-    # EC2 인스턴스 접속 및 애플리케이션 실행
+    # EC2 인스턴스에 접속하여 docker-compose로 애플리케이션과 Redis를 실행하는 단계
     - name: Application Run
       uses: appleboy/ssh-action@v0.1.6
       with:
@@ -62,14 +62,7 @@ jobs:
         key: ${{ secrets.EC2_KEY }}
 
         script: |
-          sudo docker kill ${{ secrets.PROJECT_NAME }}
-          sudo docker rm -f ${{ secrets.PROJECT_NAME }}
-          sudo docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}
-          sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}
-
-          sudo docker run -p ${{ secrets.PORT }}:${{ secrets.PORT }} \
-          --name ${{ secrets.PROJECT_NAME }} \
-          -e SPRING_DATASOURCE_URL=${{ secrets.DB_URL }} \
-          -e SPRING_DATASOURCE_USERNAME=${{ secrets.DB_USERNAME }} \
-          -e SPRING_DATASOURCE_PASSWORD=${{ secrets.DB_PASSWORD }} \
-          -d ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}
+          cd ~/realtimetrip
+          sudo docker compose pull
+          sudo docker compose down
+          sudo docker compose up -d

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ build/
 *.properties
 *.yml
 
+# docker-compose.yml 추적 예외 처리
+!docker-compose.yml
+
 ### STS ###
 .apt_generated
 .classpath

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM amazoncorretto:17
 
-# COPY ./build/libs/<프로젝트명>-<버전>-SNAPSHOT.jar app.jar
-COPY ./build/libs/realtimetrip-0.0.1-SNAPSHOT.jar app.jar
+COPY ./build/libs/*SNAPSHOT.jar app.jar
 
 ENTRYPOINT ["java", "-jar", "app.jar"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM amazoncorretto:17
 
+WORKDIR /app
+
 COPY ./build/libs/*SNAPSHOT.jar app.jar
 
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   app:
     image: "${DOCKERHUB_USERNAME}/${PROJECT_NAME}:latest"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  app:
+    image: "${DOCKERHUB_USERNAME}/${PROJECT_NAME}:latest"
+    ports:
+      - "${PORT}:${PORT}"
+    environment:
+      SPRING_DATASOURCE_URL: ${DB_URL}
+      SPRING_DATASOURCE_USERNAME: ${DB_USERNAME}
+      SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD}
+    depends_on:
+      - redis
+  redis:
+    image: redis:7
+    container_name: redis
+    ports:
+      - "6379:6379"
+    restart: always
+    command: redis-server --appendonly yes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,5 @@ services:
       - "6379:6379"
     restart: always
     command: redis-server --appendonly yes
+    volumes:
+      - ./redis-data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,10 @@ services:
     image: "${DOCKERHUB_USERNAME}/${PROJECT_NAME}:latest"
     ports:
       - "${PORT}:${PORT}"
+    volumes:
+      - ./application.yml:/app/config/application.yml
     environment:
-      SPRING_DATASOURCE_URL: ${DB_URL}
-      SPRING_DATASOURCE_USERNAME: ${DB_USERNAME}
-      SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD}
+      - SPRING_CONFIG_LOCATION=file:/app/config/application.yml
     depends_on:
       - redis
   redis:


### PR DESCRIPTION
## 개요
CI/CD 파이프라인을 docker-compose 기반으로 리팩토링했습니다. EC2 서버에서 .env 및 application.yml 자동 생성과 함께 Redis와 Spring Boot 앱이 함께 실행되도록 구성했습니다.

## 주요 변경 사항

### Dockerfile 수정
- `WORKDIR` 설정으로 실행 경로 명확화
- `*SNAPSHOT.jar`로 JAR 경로 단순화

### docker-compose.yml 생성
- app: 환경변수(.env) 기반 Spring Boot 컨테이너 실행
- Redis 컨테이너 추가: AOF 설정 + ./redis-data:/data 볼륨으로 데이터 영속성 확보
- application.yml을 외부에서 마운트

### GitHub Actions (gradle.yml) 수정
- EC2에 .env, application.yml 파일 자동 생성
- docker-compose.yml 전송 및 자동 실행
- Spring Boot 앱과 Redis를 동시에 배포 및 실행
